### PR TITLE
Add simple unit test for sleep average

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ calendar: # make calendar
 .PHONY: dashboard
 dashboard: # make dashboard
 	@echo "make dashboard"
-	@cd dashboard && uv run streamlit run 0_🏠_Home.py
+	@uv run streamlit run dashboard/0_🏠_Home.py
 
 .PHONY: dbt
 dbt: # run dbt models

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,0 +1,1 @@
+# Package for Streamlit dashboard

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,3 +10,6 @@ uv run ruff check
 
 echo "run sqlfluff"
 uv run sqlfluff lint --dialect duckdb --templater dbt transforms/models/
+
+echo "run pytest"
+uv run pytest

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,4 +12,4 @@ echo "run sqlfluff"
 uv run sqlfluff lint --dialect duckdb --templater dbt transforms/models/
 
 echo "run pytest"
-uv run pytest
+PYTHONPATH=dashboard uv run pytest

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,20 @@
+import polars as pl
+from datetime import datetime
+
+from dashboard.helpers import compute_avg_sleep_time
+
+
+def test_compute_avg_sleep_time_midnight():
+    df = pl.DataFrame(
+        {
+            "sleep_times": [
+                datetime(2023, 1, 1, 23, 30),
+                datetime(2023, 1, 2, 0, 30),
+            ]
+        }
+    )
+
+    result = compute_avg_sleep_time(df)
+
+    expected = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+    assert result == expected

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,6 @@
-import polars as pl
 from datetime import datetime
+
+import polars as pl
 
 from dashboard.helpers import compute_avg_sleep_time
 


### PR DESCRIPTION
## Summary
- add a first test suite `tests/test_helpers.py`
- cover `compute_avg_sleep_time` with a midnight case

## Testing
- `./scripts/test.sh` *(fails: unable to download build standalone due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684174d18260832784682dc5bbc4c646