### PR TITLE
Fix sleep time average when no data

### DIFF
--- a/dashboard/helpers.py
+++ b/dashboard/helpers.py
@@ -58,7 +58,7 @@ def convert_column_to_timezone(
 
 def compute_avg_sleep_time_from_midnight(
     df: pl.DataFrame, time_col: str = "sleep_times"
-) -> datetime:
+) -> datetime | None:
     """
     Computes the average sleep time as an offset from midnight,
     treating times before midnight as negative offsets.
@@ -72,6 +72,8 @@ def compute_avg_sleep_time_from_midnight(
     """
     # Extract times as list of Python datetime objects
     times = df[time_col].to_list()
+    if not times:
+        return None
 
     offsets = []
     for dt in times:
@@ -92,8 +94,11 @@ def compute_avg_sleep_time_from_midnight(
     return midnight_today + avg_offset
 
 
-def compute_avg_sleep_time(df: pl.DataFrame, time_col: str = "sleep_times") -> datetime:
+def compute_avg_sleep_time(df: pl.DataFrame, time_col: str = "sleep_times") -> datetime | None:
     times = df[time_col].to_list()
+
+    if not times:
+        return None
 
     SECONDS_IN_DAY = 24 * 60 * 60
     anchor_hour = 19  # 7 PM


### PR DESCRIPTION
## Summary
- prevent `compute_avg_sleep_time*` helpers from crashing when no rows are present

## Testing
- `bash scripts/test.sh` *(fails: unable to download python)*

------
https://chatgpt.com/codex/tasks/task_e_6841732438008327ae51af5074e7cf7f