### PR TITLE
Fix calendar path in README diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ graph LR
     B[AWS REST API] --> C[fa:fa-aws AWS Lambda]
     C -->|ingest/lambda.py| D[saves to json]
     D -->|dbt-duckdb| E[transforms data and saves out to delta]
-    E -->|calenadr/lambda.py| F[create `ics` file <br> apple-health-calendar.ics]
+    E -->|calendar/lambda.py| F[create `ics` file <br> apple-health-calendar.ics]
 ```
 
 ## 🎯 Project Goals


### PR DESCRIPTION
## Summary
- fix path to `calendar/lambda.py` in the README's mermaid diagram

## Testing
- `make test` *(fails: error sending request for url)*

------
https://chatgpt.com/codex/tasks/task_e_684174cb373483279822bc4cc7bc8a11